### PR TITLE
🦠 fix(qa): detect all Biome finding severities as failures

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - name: Lint
-            command: bun biome ci --reporter=github
+            command: bun scripts/biome-lint.ts ci --reporter=github
           - name: Type Check
             command: echo "::add-matcher::.github/matchers/tsc.json" && tsc --noEmit --skipLibCheck --pretty false
           - name: Test

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"start": "bun ./src/index.ts",
 		"qa": "bun scripts/qa.ts",
 		"qa:format": "biome format --write",
-		"qa:lint": "biome check",
+		"qa:lint": "bun scripts/biome-lint.ts check",
 		"qa:tsc": "tsc --noEmit --skipLibCheck",
 		"qa:test": "bun test && bun scripts/check-coverage.ts"
 	},

--- a/scripts/biome-lint.ts
+++ b/scripts/biome-lint.ts
@@ -1,0 +1,52 @@
+/**
+ * Biome lint wrapper that treats all finding severities (info, warn, error) as failures.
+ *
+ * Biome's exit code only reflects `error` findings by default, and `--error-on-warnings`
+ * covers `warn` but there is no equivalent for `info`. This wrapper runs biome with all
+ * provided arguments, streams output through to the caller (preserving GitHub reporter
+ * annotations in CI), and exits non-zero if any findings are detected in the output.
+ *
+ * Usage:
+ *   bun scripts/biome-lint.ts check              # local QA
+ *   bun scripts/biome-lint.ts ci --reporter=github  # CI
+ */
+
+import process from 'node:process';
+
+/** Matches Biome's "Found N error(s)" / "Found N info" / "Found N warn" output. */
+const RE_FOUND_FINDINGS = /Found \d+ (error|warn|info)/;
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+	process.stderr.write(
+		'Usage: bun scripts/biome-lint.ts <check|ci> [...biome flags]\n',
+	);
+	process.exit(1);
+}
+
+const proc = Bun.spawn(['bun', 'biome', ...args], {
+	stdout: 'pipe',
+	stderr: 'pipe',
+});
+
+const [stdout, stderr] = await Promise.all([
+	new Response(proc.stdout).text(),
+	new Response(proc.stderr).text(),
+]);
+
+const code = await proc.exited;
+
+// Write buffered output so callers (QA script, CI) see it as-is
+if (stdout) {
+	process.stdout.write(stdout);
+}
+if (stderr) {
+	process.stderr.write(stderr);
+}
+
+const combined = `${stdout}${stderr}`;
+const hasFindings = RE_FOUND_FINDINGS.test(combined);
+
+// Exit non-zero if biome failed OR any findings were detected
+process.exit(code !== 0 || hasFindings ? 1 : 0);

--- a/scripts/qa.ts
+++ b/scripts/qa.ts
@@ -47,6 +47,8 @@ const RE_FORMATTED_FILES = /Formatted (\d+) file/;
 const RE_CHECKED_FILES = /Checked (\d+) file/;
 /** Matches Biome's "Found N error(s)" output. */
 const RE_FOUND_ERRORS = /Found (\d+) error/;
+/** Matches all Biome "Found N info" or "Found N warn" occurrences in output. */
+const RE_FOUND_INFO_WARN_G = /Found (\d+) (info|warn)/g;
 /** Matches Bun test runner's "N pass" output. */
 const RE_TEST_PASS = /(\d+) pass/;
 /** Matches Bun test runner's "N fail" output. */
@@ -97,8 +99,15 @@ const steps: StepDef[] = [
 				const checked = RE_CHECKED_FILES.exec(out);
 				return checked ? `${checked[1]} files` : '';
 			}
+			const parts: string[] = [];
 			const errors = RE_FOUND_ERRORS.exec(out);
-			return errors ? `${errors[1]} error(s)` : 'failed';
+			if (errors) {
+				parts.push(`${errors[1]} error(s)`);
+			}
+			for (const match of out.matchAll(RE_FOUND_INFO_WARN_G)) {
+				parts.push(`${match[1]} ${match[2]} finding(s)`);
+			}
+			return parts.length > 0 ? parts.join(', ') : 'failed';
 		},
 	},
 	{
@@ -163,7 +172,6 @@ async function runStep(def: StepDef): Promise<StepResult> {
 	]);
 	const code = await proc.exited;
 	const output = `${stdout}${stderr}`.trim();
-
 	return {
 		name: def.name,
 		passed: code === 0,
@@ -293,13 +301,45 @@ function printAndExit(results: StepResult[], passed: boolean): never {
 	process.exit(passed ? 0 : 1);
 }
 
+/** CSI u prefix used by the Kitty keyboard protocol (`ESC [`). */
+const CSI_PREFIX = '\x1b[';
+
+/**
+ * Normalizes Kitty keyboard protocol sequences to standard key values.
+ *
+ * Kitty protocol encodes keys as `ESC [ <code> ; <modifiers> u`. This converts
+ * them to their standard equivalents so key handlers work across terminals.
+ */
+function normalizeKey(raw: string): string {
+	if (!(raw.startsWith(CSI_PREFIX) && raw.endsWith('u'))) {
+		return raw;
+	}
+
+	const inner = raw.slice(CSI_PREFIX.length, -1);
+	const [codeStr, modStr] = inner.split(';');
+	const code = Number(codeStr);
+	const mods = modStr ? Number(modStr) - 1 : 0;
+
+	// biome-ignore lint/suspicious/noBitwiseOperators: bitwise mask extracts Ctrl modifier flag per Kitty protocol spec
+	const isCtrl = (mods & 4) !== 0;
+
+	// Ctrl+letter → control character (e.g. Ctrl+C → 0x03)
+	if (isCtrl && code >= 97 && code <= 122) {
+		return String.fromCodePoint(code - 96);
+	}
+
+	return String.fromCodePoint(code);
+}
+
 /** Handles a single keypress in interactive mode. */
 function handleKey(
-	key: string,
+	raw: string,
 	state: { cursor: number },
 	results: StepResult[],
 	passed: boolean,
 ): void {
+	const key = normalizeKey(raw);
+
 	if (key === 'q' || key === '\x03') {
 		process.stdout.write(SHOW_CURSOR);
 		process.stdin.setRawMode(false);
@@ -316,7 +356,7 @@ function handleKey(
 		render(results, state.cursor, passed);
 	}
 
-	if (key === '\r' || key === ' ') {
+	if (key === '\r' || key === '\n' || key === ' ') {
 		const selected = results[state.cursor];
 		if (selected) {
 			selected.expanded = !selected.expanded;


### PR DESCRIPTION
## Summary
- Add `scripts/biome-lint.ts` wrapper that exits non-zero on any Biome finding (info, warn, error) — Biome has no `--error-on-info` flag, so info findings were invisible
- Update `qa:lint` and CI workflow to route through the wrapper
- Fix interactive QA viewer: Enter/Space didn't work in terminals using the Kitty keyboard protocol (e.g. Ghostty, WezTerm)
- Improve lint summary to show all finding severities (e.g. "2 error(s), 3 info finding(s)")

## Test plan
- [x] `bun qa:format` — no fixes needed
- [x] `bun qa:tsc` — passes clean
- [x] `bun biome check scripts/biome-lint.ts scripts/qa.ts` — zero findings
- [x] `bun qa` — interactive viewer Enter/Space works, lint findings reported correctly
- [ ] Verify CI lint job uses wrapper and fails on info findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Lint commands now route through a project script that treats all lint severities (info, warn, error) as failures, enforcing stricter CI/local checks.
  * Terminal/keyboard handling improved for interactive flows: broader key normalization for terminal sequences and added newline as an activation key for better compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->