### PR TITLE
🌈 improve(config): add Renovate commit format and squash strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
 		"group:allNonMajor",
 		":separateMajorReleases"
 	],
+	"commitMessagePrefix": "🧺 chore(deps):",
+	"commitMessageAction": "update",
+	"automergeStrategy": "squash",
 	"baseBranchPatterns": ["develop"],
 	"labels": ["dependencies"],
 	"timezone": "America/Chicago",


### PR DESCRIPTION
## Summary
- Add `commitMessagePrefix` and `commitMessageAction` to match project commit format (`🧺 chore(deps): update ...`)
- Add `automergeStrategy: squash` for cleaner merge history

## Test plan
- [ ] Verify next Renovate PR uses the configured commit format
- [ ] Verify automerge uses squash strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to optimize dependency update automation, including custom commit message formatting and merge strategy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->